### PR TITLE
Add pull-requests: write permission to CI workflow

### DIFF
--- a/.github/workflows/ghbuild.yml
+++ b/.github/workflows/ghbuild.yml
@@ -19,5 +19,9 @@ on:
 
 jobs:
   # This workflow contains a single job called "build"
-  call_build: 
+  call_build:
+    permissions:
+      contents: write        # for gh-pages deploy
+      pull-requests: write   # for PR build-status comments
     uses: WorldHealthOrganization/smart-base/.github/workflows/ghbuild.yml@main
+    secrets: inherit


### PR DESCRIPTION
## Summary\n- Add `pull-requests: write` permission to the `call_build` job in `ghbuild.yml` so the reusable workflow from smart-base can post PR build-status comments\n- Add `contents: write` permission (for gh-pages deploy)\n- Add `secrets: inherit` so the called workflow receives the necessary tokens\n\n## Context\nPR builds were failing with 403 errors when trying to post PR comments because the `GITHUB_TOKEN` lacked `pull-requests: write` permission.\n\n## Test plan\n- [ ] Verify CI workflow runs successfully on this PR\n- [ ] Verify PR build-status comments appear on future PRs\n\nhttps://claude.ai/code/session_01KWnVgvsDBdeHFY4JLyBjHx