### PR TITLE
Add pull-requests: write permission to CI workflow

### DIFF
--- a/.github/workflows/ghbuild.yml
+++ b/.github/workflows/ghbuild.yml
@@ -19,5 +19,9 @@ on:
 
 jobs:
   # This workflow contains a single job called "build"
-  call_build: 
+  call_build:
+    permissions:
+      contents: write        # for gh-pages deploy
+      pull-requests: write   # for PR build-status comments
     uses: WorldHealthOrganization/smart-base/.github/workflows/ghbuild.yml@main
+    secrets: inherit


### PR DESCRIPTION
## Summary

- Add `pull-requests: write` permission to the `call_build` job so the reusable `ghbuild.yml` workflow can post PR build-status comments (fixes 403 errors)
- Add `contents: write` permission (for gh-pages deploy)
- Add `secrets: inherit` so the called workflow receives necessary secrets

## Context

PR builds were failing with `403 Forbidden` when trying to post PR comments because the `GITHUB_TOKEN` lacked `pull-requests: write` permission. The smart-base reusable workflow (`ghbuild.yml`) includes steps that post build status as PR comments, which requires this permission.

## Test plan

- [ ] Verify CI workflow runs successfully on this PR
- [ ] Confirm PR build-status comments are posted without 403 errors

https://claude.ai/code/session_015NaJzfWJnJhgmdP6xjpqTL